### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server that provides access to [For Five Coffee](https://for-five-coffee.ordrsliponline.com/menus) menu data. Works with Claude Desktop, Cursor, and other MCP clients, plus provides a REST API.
 
+<a href="https://glama.ai/mcp/servers/@Kong/menu-mpc">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Kong/menu-mpc/badge" alt="For Five Coffee Server MCP server" />
+</a>
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [For Five Coffee MCP Server](https://glama.ai/mcp/servers/@Kong/menu-mpc) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Kong/menu-mpc">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Kong/menu-mpc/badge" alt="For Five Coffee Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.